### PR TITLE
Replace VM resource's `wait_for_ip` functionality to validate it whether the ip(s) match a given prefix

### DIFF
--- a/docs/data-sources/vms.md
+++ b/docs/data-sources/vms.md
@@ -84,7 +84,6 @@ Read-Only:
 - `template` (String)
 - `vga` (String)
 - `videoram` (Number)
-- `wait_for_ip` (Boolean)
 - `xenstore` (Map of String)
 
 <a id="nestedobjatt--vms--disk"></a>
@@ -109,6 +108,7 @@ Read-Only:
 
 - `attached` (Boolean)
 - `device` (String)
+- `expected_ip_cidr` (String)
 - `ipv4_addresses` (List of String)
 - `ipv6_addresses` (List of String)
 - `mac_address` (String)

--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -98,13 +98,14 @@ resource "xenorchestra_vm" "bar" {
     }
 }
 
-# vm resource that uses wait_for_ip
+# vm resource that waits until its first network interface
+# is assigned an IP via DHCP
 resource "xenorchestra_vm" "vm" {
   ...
-  wait_for_ip = true
   # Specify VM with two network interfaces
   network {
     ...
+    expected_ip_cidr = "10.0.0.0/16"
   }
   network {
     ...
@@ -176,14 +177,13 @@ $ xo-cli xo.getAllObjects filter='json:{"id": "cf7b5d7d-3cd5-6b7c-5025-5c935c8cd
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `vga` (String) The video adapter the VM should use. Possible values include std and cirrus.
 - `videoram` (Number) The videoram option the VM should use. Possible values include 1, 2, 4, 8, 16
-- `wait_for_ip` (Boolean) Whether terraform should wait until IP addresses are present on the VM's network interfaces before considering it created. This only works if guest-tools are installed in the VM. Defaults to false.
 - `xenstore` (Map of String) The key value pairs to be populated in xenstore.
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-- `ipv4_addresses` (List of String) This is only accessible if guest-tools is installed in the VM and if `wait_for_ip` is set to true. This will contain a list of the ipv4 addresses across all network interfaces in order. See the example terraform code for more details.
-- `ipv6_addresses` (List of String) This is only accessible if guest-tools is installed in the VM and if `wait_for_ip` is set to true. This will contain a list of the ipv6 addresses across all network interfaces in order.
+- `ipv4_addresses` (List of String) This is only accessible if guest-tools is installed in the VM and if `expected_ip_cidr` is set on any network interfaces. This will contain a list of the ipv4 addresses across all network interfaces in order. See the example terraform code for more details.
+- `ipv6_addresses` (List of String) This is only accessible if guest-tools is installed in the VM and if `expected_ip_cidr` is set on any network interfaces. This will contain a list of the ipv6 addresses across all network interfaces in order.
 
 <a id="nestedblock--disk"></a>
 ### Nested Schema for `disk`
@@ -216,6 +216,7 @@ Required:
 Optional:
 
 - `attached` (Boolean) Whether the device should be attached to the VM.
+- `expected_ip_cidr` (String) Whether terraform should wait until IP addresses are present on the VM's network interfaces before considering it created. This only works if guest-tools are installed in the VM. Defaults to false.
 - `mac_address` (String) The mac address of the network interface. This must be parsable by go's [net.ParseMAC function](https://golang.org/pkg/net/#ParseMAC). All mac addresses are stored in Terraform's state with [HardwareAddr's string representation](https://golang.org/pkg/net/#HardwareAddr.String) i.e. 00:00:5e:00:53:01
 
 Read-Only:

--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -216,7 +216,7 @@ Required:
 Optional:
 
 - `attached` (Boolean) Whether the device should be attached to the VM.
-- `expected_ip_cidr` (String) Whether terraform should wait until IP addresses are present on the VM's network interfaces before considering it created. This only works if guest-tools are installed in the VM. Defaults to false.
+- `expected_ip_cidr` (String) Determines the IP cidr range terraform should watch for on this network interface. Resource creation is not complete until the IP address converges to the specified range. This only works if guest-tools are installed in the VM. Defaults to "", which skips IP address matching.
 - `mac_address` (String) The mac address of the network interface. This must be parsable by go's [net.ParseMAC function](https://golang.org/pkg/net/#ParseMAC). All mac addresses are stored in Terraform's state with [HardwareAddr's string representation](https://golang.org/pkg/net/#HardwareAddr.String) i.e. 00:00:5e:00:53:01
 
 Read-Only:

--- a/examples/resources/xenorchestra_vm/resource.tf
+++ b/examples/resources/xenorchestra_vm/resource.tf
@@ -67,13 +67,14 @@ resource "xenorchestra_vm" "bar" {
     }
 }
 
-# vm resource that uses wait_for_ip
+# vm resource that waits until its first network interface
+# is assigned an IP via DHCP
 resource "xenorchestra_vm" "vm" {
   ...
-  wait_for_ip = true
   # Specify VM with two network interfaces
   network {
     ...
+    expected_ip_cidr = "10.0.0.0/16"
   }
   network {
     ...

--- a/xoa/data_source_vms.go
+++ b/xoa/data_source_vms.go
@@ -84,7 +84,6 @@ func vmToMapList(vms []client.Vm) []map[string]interface{} {
 			"memory_max":           vm.Memory.Static[1],
 			"affinity_host":        vm.AffinityHost,
 			"template":             vm.Template,
-			"wait_for_ip":          vm.WaitForIps,
 			"high_availability":    vm.HA,
 			"ipv4_addresses":       ipv4,
 			"ipv6_addresses":       ipv6,

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -354,7 +354,7 @@ $ xo-cli xo.getAllObjects filter='json:{"id": "cf7b5d7d-3cd5-6b7c-5025-5c935c8cd
 					"expected_ip_cidr": &schema.Schema{
 						Type:        schema.TypeString,
 						Default:     "",
-						Description: "Whether terraform should wait until IP addresses are present on the VM's network interfaces before considering it created. This only works if guest-tools are installed in the VM. Defaults to false.",
+						Description: "Determines the IP cidr range terraform should watch for on this network interface. Resource creation is not complete until the IP address converges to the specified range. This only works if guest-tools are installed in the VM. Defaults to \"\", which skips IP address matching.",
 						Optional:    true,
 					},
 				},

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -12,11 +12,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/vatesfr/terraform-provider-xenorchestra/client"
 	"github.com/vatesfr/terraform-provider-xenorchestra/xoa/internal"
 	"github.com/vatesfr/terraform-provider-xenorchestra/xoa/internal/state"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 var validVga = []string{
@@ -530,7 +530,7 @@ func resourceVmCreate(d *schema.ResourceData, m interface{}) error {
 
 	if installMethod := d.Get("installation_method").(string); installMethod != "" {
 		installation = client.Installation{
-			Method: "network",
+			Method:     "network",
 			Repository: "pxe",
 		}
 	}

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -239,14 +239,14 @@ $ xo-cli xo.getAllObjects filter='json:{"id": "cf7b5d7d-3cd5-6b7c-5025-5c935c8cd
 		"ipv4_addresses": &schema.Schema{
 			Type:        schema.TypeList,
 			Computed:    true,
-			Description: "This is only accessible if guest-tools is installed in the VM and if `wait_for_ip` is set to true. This will contain a list of the ipv4 addresses across all network interfaces in order. See the example terraform code for more details.",
+			Description: "This is only accessible if guest-tools is installed in the VM and if `expected_ip_cidr` is set on any network interfaces. This will contain a list of the ipv4 addresses across all network interfaces in order. See the example terraform code for more details.",
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
 			},
 		},
 		"ipv6_addresses": &schema.Schema{
 			Type:        schema.TypeList,
-			Description: "This is only accessible if guest-tools is installed in the VM and if `wait_for_ip` is set to true. This will contain a list of the ipv6 addresses across all network interfaces in order.",
+			Description: "This is only accessible if guest-tools is installed in the VM and if `expected_ip_cidr` is set on any network interfaces. This will contain a list of the ipv6 addresses across all network interfaces in order.",
 			Computed:    true,
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
@@ -280,12 +280,6 @@ $ xo-cli xo.getAllObjects filter='json:{"id": "cf7b5d7d-3cd5-6b7c-5025-5c935c8cd
 		"host": &schema.Schema{
 			Type:     schema.TypeString,
 			Optional: true,
-		},
-		"wait_for_ip": &schema.Schema{
-			Type:        schema.TypeBool,
-			Default:     false,
-			Description: "Whether terraform should wait until IP addresses are present on the VM's network interfaces before considering it created. This only works if guest-tools are installed in the VM. Defaults to false.",
-			Optional:    true,
 		},
 		"cdrom": &schema.Schema{
 			Type:          schema.TypeList,
@@ -356,6 +350,12 @@ $ xo-cli xo.getAllObjects filter='json:{"id": "cf7b5d7d-3cd5-6b7c-5025-5c935c8cd
 						Elem: &schema.Schema{
 							Type: schema.TypeString,
 						},
+					},
+					"expected_ip_cidr": &schema.Schema{
+						Type:        schema.TypeString,
+						Default:     "",
+						Description: "Whether terraform should wait until IP addresses are present on the VM's network interfaces before considering it created. This only works if guest-tools are installed in the VM. Defaults to false.",
+						Optional:    true,
 					},
 				},
 			},
@@ -465,10 +465,11 @@ This does not work in terraform since that is applied on Xen Orchestra's client 
 func resourceVmCreate(d *schema.ResourceData, m interface{}) error {
 	c := m.(client.XOClient)
 
-	network_maps := []map[string]string{}
+	vifsMap := []map[string]string{}
+	waitForIpsMap := map[string]string{}
 	networks := d.Get("network").([]interface{})
 
-	for _, network := range networks {
+	for index, network := range networks {
 		netMap, _ := network.(map[string]interface{})
 
 		netID := netMap["network_id"].(string)
@@ -477,12 +478,17 @@ func resourceVmCreate(d *schema.ResourceData, m interface{}) error {
 		netMapToAdd := map[string]string{
 			"network": netID,
 		}
-		// We only add the mac address if it contains a value.
+		// Only add the mac address if it contains a value.
 		if macAddr != "" {
 			netMapToAdd["mac"] = getFormattedMac(macAddr)
 		}
 
-		network_maps = append(network_maps, netMapToAdd)
+		expectedCidr := netMap["expected_ip_cidr"].(string)
+		if expectedCidr != "" {
+			waitForIpsMap[strconv.Itoa(index)] = expectedCidr
+		}
+
+		vifsMap = append(vifsMap, netMapToAdd)
 	}
 
 	ds := []client.Disk{}
@@ -570,9 +576,9 @@ func resourceVmCreate(d *schema.ResourceData, m interface{}) error {
 		Installation: installation,
 		// TODO: (#145) Uncomment this once issues with secure_boot have been figured out
 		// SecureBoot:   d.Get("secure_boot").(bool),
-		VIFsMap:    network_maps,
+		VIFsMap:    vifsMap,
 		StartDelay: d.Get("start_delay").(int),
-		WaitForIps: d.Get("wait_for_ip").(bool),
+		WaitForIps: waitForIpsMap,
 		Videoram: client.Videoram{
 			Value: d.Get("videoram").(int),
 		},
@@ -682,9 +688,21 @@ func cdromsToMapList(disks []client.Disk) []map[string]interface{} {
 	return result
 }
 
-func vifsToMapList(vifs []client.VIF, guestNets []guestNetwork) []map[string]interface{} {
+func vifsToMapList(vifs []client.VIF, guestNets []guestNetwork, d *schema.ResourceData) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, len(vifs))
-	for _, vif := range vifs {
+
+	expectedCidrs := map[string]string{}
+
+	networks := d.Get("network").([]interface{})
+	for index, network := range networks {
+		netMap := network.(map[string]interface{})
+		expectedCidr := netMap["expected_ip_cidr"].(string)
+		if expectedCidr == "" {
+			continue
+		}
+		expectedCidrs[strconv.Itoa(index)] = expectedCidr
+	}
+	for index, vif := range vifs {
 		ipv6Addrs := []string{}
 		ipv4Addrs := []string{}
 		device, _ := strconv.Atoi(vif.Device)
@@ -700,6 +718,10 @@ func vifsToMapList(vifs []client.VIF, guestNets []guestNetwork) []map[string]int
 			"network_id":     vif.Network,
 			"ipv4_addresses": ipv4Addrs,
 			"ipv6_addresses": ipv6Addrs,
+		}
+
+		if cidr, ok := expectedCidrs[strconv.Itoa(index)]; ok {
+			vifMap["expected_ip_cidr"] = cidr
 		}
 		result = append(result, vifMap)
 	}
@@ -1174,11 +1196,15 @@ func recordToData(resource client.Vm, vifs []client.VIF, disks []client.Disk, cd
 	}
 
 	log.Printf("[DEBUG] Found the following ip addresses: %v\n", resource.Addresses)
-	networkIps := extractIpsFromNetworks(resource.Addresses)
-	nets := vifsToMapList(vifs, networkIps)
-	err := d.Set("network", nets)
+	networkIps, err := extractIpsFromNetworks(resource.Addresses)
 
 	if err != nil {
+		return err
+	}
+
+	nets := vifsToMapList(vifs, networkIps, d)
+	fmt.Printf("[INFO] Setting the vifsToMapList: %v\n", nets)
+	if err := d.Set("network", nets); err != nil {
 		return err
 	}
 
@@ -1418,10 +1444,10 @@ type guestNetwork map[string][]string
 //	    "ipv6": []string{"ip1", "ip2"}
 //	  },
 //	}
-func extractIpsFromNetworks(networks map[string]string) []guestNetwork {
+func extractIpsFromNetworks(networks map[string]string) ([]guestNetwork, error) {
 
 	if len(networks) < 1 {
-		return []guestNetwork{}
+		return []guestNetwork{}, nil
 	}
 
 	IP_REGEX := `^(\d+)\/(ip(?:v4|v6)?)(?:\/(\d+))?$`
@@ -1437,7 +1463,7 @@ func extractIpsFromNetworks(networks map[string]string) []guestNetwork {
 
 	matches := reg.FindStringSubmatch(last)
 	if matches == nil || len(matches) != 4 {
-		panic("this should never happen")
+		return nil, fmt.Errorf("received a malformed IP address field from XO api: line=%s regex matches=%v", last, matches)
 	}
 	cap, _ := strconv.Atoi(matches[1])
 	devices := make([]guestNetwork, 0, cap)
@@ -1463,7 +1489,7 @@ func extractIpsFromNetworks(networks map[string]string) []guestNetwork {
 		devices[deviceNum][proto] = append(devices[deviceNum][proto], networks[key])
 	}
 	log.Printf("[DEBUG] Extracted the following network interface ips: %v\n", devices)
-	return devices
+	return devices, nil
 }
 
 func suppressEquivalentMAC(k, old, new string, d *schema.ResourceData) (suppress bool) {

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -639,6 +639,7 @@ func TestAccXenorchestraVm_waitForIpFailed(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceName, "network.0.ipv6_addresses.#", regex),
 					resource.TestCheckResourceAttrSet(resourceName, "network.0.ipv6_addresses.0"),
 				),
+				ExpectError: regexp.MustCompile(`network\[0\] never converged to the following cidr: 8.8.8.8\/32`),
 			},
 		},
 	})

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/vatesfr/terraform-provider-xenorchestra/client"
-	"github.com/vatesfr/terraform-provider-xenorchestra/xoa/internal"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/xoa/internal"
 )
 
 func init() {
@@ -68,7 +68,7 @@ func Test_extractIpsFromNetworks(t *testing.T) {
 	for _, test := range tests {
 		expected := test.expected
 		nets := test.networks
-		actual := extractIpsFromNetworks(nets)
+		actual, _ := extractIpsFromNetworks(nets)
 
 		if len(expected) != len(actual) {
 			t.Errorf("expected '%+v' to have the same length as: %+v", expected, actual)
@@ -610,7 +610,6 @@ func TestAccXenorchestraVm_createWhenWaitingForIp(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccVmExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "wait_for_ip", "true"),
 					resource.TestMatchResourceAttr(resourceName, "ipv6_addresses.#", regex),
 					resource.TestCheckResourceAttrSet(resourceName, "ipv6_addresses.0"),
 					resource.TestMatchResourceAttr(resourceName, "network.0.ipv6_addresses.#", regex),
@@ -2100,9 +2099,36 @@ resource "xenorchestra_vm" "bar" {
       name_label = "disk 1"
       size = 10001317888
     }
-    wait_for_ip = %s
 }
-`, accDefaultNetwork.NameLabel, accTestPool.Id, vmName, accDefaultSr.Id, waitForIp)
+`, accDefaultNetwork.NameLabel, accTestPool.Id, vmName, accDefaultSr.Id)
+}
+
+func testAccVmConfigWithWaitForIp(vmName, expectedIpCidr string) string {
+	return testAccCloudConfigConfig(fmt.Sprintf("vm-template-%s", vmName), "template") + testAccTemplateConfig() + fmt.Sprintf(`
+data "xenorchestra_network" "network" {
+    name_label = "%s"
+    pool_id = "%s"
+}
+
+resource "xenorchestra_vm" "bar" {
+    memory_max = 4295000000
+    cpus  = 1
+    cloud_config = xenorchestra_cloud_config.bar.template
+    name_label = "%s"
+    name_description = "description"
+    template = data.xenorchestra_template.template.id
+    network {
+	network_id = data.xenorchestra_network.network.id
+	expected_ip_cidr = "%s"
+    }
+
+    disk {
+      sr_id = "%s"
+      name_label = "disk 1"
+      size = 10001317888
+    }
+}
+`, accDefaultNetwork.NameLabel, accTestPool.Id, vmName, expectedIpCidr, accDefaultSr.Id)
 }
 
 func testAccVmConfigFullClone(vmName string) string {
@@ -2163,7 +2189,7 @@ resource "xenorchestra_vm" "bar" {
 `, accDefaultNetwork.NameLabel, accTestPool.Id, vmName, accDefaultSr.Id, powerState)
 }
 
-// This sets destroy_cloud_config_vdi_after_boot and wait_for_ip. The former is required for
+// This sets destroy_cloud_config_vdi_after_boot and expected_ip_cidr. The former is required for
 // the test expectations while the latter is to ensure the test holds its assertions until the
 // disk was actually deleted. The XO api uses the guest metrics to determine when it can remove
 // the disk, so an IP address allocation happens at the same time.
@@ -2184,9 +2210,9 @@ resource "xenorchestra_vm" "bar" {
     destroy_cloud_config_vdi_after_boot = true
     network {
 	network_id = data.xenorchestra_network.network.id
+	expected_ip_cidr = "0.0.0.0/0"
     }
     power_state = "%s"
-    wait_for_ip = true
 
     disk {
       sr_id = "%s"
@@ -2347,7 +2373,6 @@ data "xenorchestra_network" "network" {
 
 resource "xenorchestra_vm" "bar" {
     memory_max = 4295000000
-    wait_for_ip = true
     cpus  = 1
     cloud_config = xenorchestra_cloud_config.bar.template
     name_label = "%s"
@@ -2355,6 +2380,7 @@ resource "xenorchestra_vm" "bar" {
     template = data.xenorchestra_template.template.id
     network {
 	network_id = data.xenorchestra_network.network.id
+	expected_ip_cidr = "0.0.0.0/0"
     }
 
     disk {
@@ -2375,7 +2401,6 @@ data "xenorchestra_network" "network" {
 
 resource "xenorchestra_vm" "bar" {
     memory_max = 4295000000
-    wait_for_ip = true
     cpus  = 1
     cloud_config = xenorchestra_cloud_config.bar.template
     name_label = "%s"
@@ -2383,6 +2408,7 @@ resource "xenorchestra_vm" "bar" {
     template = data.xenorchestra_template.template.id
     network {
 	network_id = data.xenorchestra_network.network.id
+	expected_ip_cidr = "0.0.0.0/0"
     }
 
     disk {
@@ -2413,7 +2439,6 @@ data "xenorchestra_network" "network" {
 
 resource "xenorchestra_vm" "bar" {
     memory_max = 4295000000
-    wait_for_ip = true
     cpus  = 1
     cloud_config = xenorchestra_cloud_config.bar.template
     name_label = "%s"
@@ -2421,6 +2446,7 @@ resource "xenorchestra_vm" "bar" {
     template = data.xenorchestra_template.template.id
     network {
 	network_id = data.xenorchestra_network.network.id
+	expected_ip_cidr = "0.0.0.0/0"
     }
 
     disk {

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -620,6 +620,30 @@ func TestAccXenorchestraVm_createWhenWaitingForIp(t *testing.T) {
 	})
 }
 
+func TestAccXenorchestraVm_waitForIpFailed(t *testing.T) {
+	resourceName := "xenorchestra_vm.bar"
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
+	regex := regexp.MustCompile(`[1-9]*`)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckXenorchestraVmDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVmConfigWithWaitForIp(vmName, "8.8.8.8/32"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccVmExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestMatchResourceAttr(resourceName, "ipv6_addresses.#", regex),
+					resource.TestCheckResourceAttrSet(resourceName, "ipv6_addresses.0"),
+					resource.TestMatchResourceAttr(resourceName, "network.0.ipv6_addresses.#", regex),
+					resource.TestCheckResourceAttrSet(resourceName, "network.0.ipv6_addresses.0"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccXenorchestraVm_createAndUpdateXenstoreData(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
 	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
@@ -1376,7 +1400,7 @@ func TestAccXenorchestraVm_addVifAndRemoveVif(t *testing.T) {
 		CheckDestroy: testAccCheckXenorchestraVmDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVmConfigWithWaitForIp(vmName, "true"),
+				Config: testAccVmConfigWithWaitForIp(vmName, "0.0.0.0/0"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccVmExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
@@ -1810,7 +1834,7 @@ func TestAccXenorchestraVm_createWithV0StateMigration(t *testing.T) {
 						VersionConstraint: "0.25.1",
 					},
 				},
-				Config: testAccVmConfigWithWaitForIp(vmName, "true"),
+				Config: testAccVmConfigWithWaitForIp(vmName, "0.0.0.0/0"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccVmExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -2108,7 +2108,7 @@ resource "xenorchestra_vm" "bar" {
 }
 
 func testAccVmConfig(vmName string) string {
-	return testAccVmConfigWithWaitForIp(vmName, "0.0.0.0/0")
+	return testAccVmConfigWithWaitForIp(vmName, "")
 }
 
 func testAccVmConfigWithWaitForIp(vmName, expectedIpCidr string) string {


### PR DESCRIPTION
Summary: Replace VM resource's `wait_for_ip` functionality to validate it whether the ip(s) match a given prefix

This PR is a work in progress change for addressing #300.

Testing done:
- [x] Replace existing functionality with a `network` block scoped `expected_ip_cidr`
- [x] Implement matching logic for multiple cidr ranges
- [x] Add test that simulates an upgrade from the previous `wait_for_ip` to the current per network interface `expected_cidr_range` configuration.