### PR TITLE
Fix module path for pulumi support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,12 @@
 # This GitHub action can publish assets for release when a tag is created.
 # Currently its setup to run on any tag that matches the pattern "v*" (ie. v0.1.0).
 #
-# This uses an action (paultyng/ghaction-import-gpg) that assumes you set your 
+# This uses an action (paultyng/ghaction-import-gpg) that assumes you set your
 # private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
 # secret. If you would rather own your own GPG handling, please fork this action
 # or use an alternative one for key handling.
 #
-# You will need to pass the `--batch` flag to `gpg` in your signing step 
+# You will need to pass the `--batch` flag to `gpg` in your signing step
 # in `goreleaser` to indicate this is being used in a non-interactive mode.
 #
 name: release

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ GOMAXPROCS ?= 5
 TF_VERSION ?= v0.14.11
 ROOT_PKG_PATH := github.com/ddelnano/terraform-provider-xenorchestra
 ifdef TEST
-    TEST := github.com/ddelnano/terraform-provider-xenorchestra/xoa -run '$(TEST)'
+    TEST := github.com/vatesfr/terraform-provider-xenorchestra/xoa -run '$(TEST)'
 else
     TEST := ./...
 endif

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 TIMEOUT ?= 40m
 GOMAXPROCS ?= 5
 TF_VERSION ?= v0.14.11
-ROOT_PKG_PATH := github.com/ddelnano/terraform-provider-xenorchestra
+ROOT_PKG_PATH := github.com/vatesfr/terraform-provider-xenorchestra
 ifdef TEST
     TEST := github.com/vatesfr/terraform-provider-xenorchestra/xoa -run '$(TEST)'
 else

--- a/client/go.mod
+++ b/client/go.mod
@@ -1,4 +1,4 @@
-module github.com/ddelnano/terraform-provider-xenorchestra/client
+module github.com/vatesfr/terraform-provider-xenorchestra/client
 
 go 1.21
 

--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -129,7 +129,7 @@ $ xo-cli xo.getAllObjects filter='json:{"id": "cf7b5d7d-3cd5-6b7c-5025-5c935c8cd
   "max": 4,
   "number": 2
 }
-		    
+
 # Updating the VM to use 3 CPUs would happen without stopping/starting the VM
 # Updating the VM to use 5 CPUs would stop/start the VM
 ```

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,9 @@ module github.com/vatesfr/terraform-provider-xenorchestra
 go 1.21
 
 require (
-	github.com/cenkalti/backoff/v3 v3.2.2
-	github.com/gorilla/websocket v1.4.2
+	github.com/vatesfr/terraform-provider-xenorchestra/client v0.0.0-00010101000000-000000000000
 	github.com/hashicorp/terraform-plugin-docs v0.18.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
-	github.com/mitchellh/mapstructure v1.5.0
-	github.com/sourcegraph/jsonrpc2 v0.0.0-20210201082850-366fbb520750
 )
 
 require (
@@ -21,11 +18,13 @@ require (
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
+	github.com/cenkalti/backoff/v3 v3.2.2 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/uuid v1.4.0 // indirect
+	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/hashicorp/cli v1.1.6 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
@@ -54,11 +53,13 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/russross/blackfriday v1.6.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
+	github.com/sourcegraph/jsonrpc2 v0.0.0-20210201082850-366fbb520750 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
@@ -78,3 +79,5 @@ require (
 	google.golang.org/protobuf v1.32.0 // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 )
+
+replace github.com/vatesfr/terraform-provider-xenorchestra/client => ./client

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,14 @@
-module github.com/ddelnano/terraform-provider-xenorchestra
+module github.com/vatesfr/terraform-provider-xenorchestra
 
 go 1.21
 
 require (
-	github.com/ddelnano/terraform-provider-xenorchestra/client v0.0.0-00010101000000-000000000000
+	github.com/cenkalti/backoff/v3 v3.2.2
+	github.com/gorilla/websocket v1.4.2
 	github.com/hashicorp/terraform-plugin-docs v0.18.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
+	github.com/mitchellh/mapstructure v1.5.0
+	github.com/sourcegraph/jsonrpc2 v0.0.0-20210201082850-366fbb520750
 )
 
 require (
@@ -18,13 +21,11 @@ require (
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
-	github.com/cenkalti/backoff/v3 v3.2.2 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/uuid v1.4.0 // indirect
-	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/hashicorp/cli v1.1.6 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
@@ -53,13 +54,11 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
-	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/russross/blackfriday v1.6.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
-	github.com/sourcegraph/jsonrpc2 v0.0.0-20210201082850-366fbb520750 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
@@ -79,5 +78,3 @@ require (
 	google.golang.org/protobuf v1.32.0 // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 )
-
-replace github.com/ddelnano/terraform-provider-xenorchestra/client => ./client

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"log"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/xoa"
+	"github.com/vatesfr/terraform-provider-xenorchestra/xoa"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 )
 

--- a/xoa/acc_setup_test.go
+++ b/xoa/acc_setup_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 

--- a/xoa/data_source_cloud_config.go
+++ b/xoa/data_source_cloud_config.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/xoa/data_source_cloud_config_test.go
+++ b/xoa/data_source_cloud_config_test.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )

--- a/xoa/data_source_host.go
+++ b/xoa/data_source_host.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/xoa/data_source_hosts.go
+++ b/xoa/data_source_hosts.go
@@ -3,7 +3,7 @@ package xoa
 import (
 	"log"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/xoa/data_source_hosts_test.go
+++ b/xoa/data_source_hosts_test.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/xoa/internal"
+	"github.com/vatesfr/terraform-provider-xenorchestra/xoa/internal"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )

--- a/xoa/data_source_pool.go
+++ b/xoa/data_source_pool.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/xoa/data_source_resource_set.go
+++ b/xoa/data_source_resource_set.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/xoa/data_source_resource_set_test.go
+++ b/xoa/data_source_resource_set_test.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )

--- a/xoa/data_source_user.go
+++ b/xoa/data_source_user.go
@@ -3,7 +3,7 @@ package xoa
 import (
 	"log"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/xoa/data_source_vms.go
+++ b/xoa/data_source_vms.go
@@ -4,8 +4,8 @@ import (
 	"log"
 	"strings"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
-	"github.com/ddelnano/terraform-provider-xenorchestra/xoa/internal"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/xoa/internal"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/xoa/data_source_xenorchestra_network.go
+++ b/xoa/data_source_xenorchestra_network.go
@@ -1,7 +1,7 @@
 package xoa
 
 import (
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/xoa/data_source_xenorchestra_network_test.go
+++ b/xoa/data_source_xenorchestra_network_test.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )

--- a/xoa/data_source_xenorchestra_pif.go
+++ b/xoa/data_source_xenorchestra_pif.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/xoa/data_source_xenorchestra_sr.go
+++ b/xoa/data_source_xenorchestra_sr.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/xoa/data_source_xenorchestra_template.go
+++ b/xoa/data_source_xenorchestra_template.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/xoa/data_source_xenorchestra_vdi.go
+++ b/xoa/data_source_xenorchestra_vdi.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/xoa/internal/mocks.go
+++ b/xoa/internal/mocks.go
@@ -3,7 +3,7 @@ package internal
 import (
 	"errors"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/xoa/internal/state/migrate.go
+++ b/xoa/internal/state/migrate.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -145,7 +145,7 @@ $ xo-cli xo.getAllObjects filter='json:{"id": "cf7b5d7d-3cd5-6b7c-5025-5c935c8cd
   "max": 4,
   "number": 2
 }
-		    
+
 # Updating the VM to use 3 CPUs would happen without stopping/starting the VM
 # Updating the VM to use 5 CPUs would stop/start the VM`,
 			},

--- a/xoa/provider.go
+++ b/xoa/provider.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/xoa/provider_test.go
+++ b/xoa/provider_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/xoa/internal"
+	"github.com/vatesfr/terraform-provider-xenorchestra/xoa/internal"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/xoa/resource_user_test.go
+++ b/xoa/resource_user_test.go
@@ -1,7 +1,7 @@
 package xoa
 
 import (
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 

--- a/xoa/resource_xenorchestra_acl.go
+++ b/xoa/resource_xenorchestra_acl.go
@@ -1,7 +1,7 @@
 package xoa
 
 import (
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/xoa/resource_xenorchestra_acl_test.go
+++ b/xoa/resource_xenorchestra_acl_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )

--- a/xoa/resource_xenorchestra_bonded_network.go
+++ b/xoa/resource_xenorchestra_bonded_network.go
@@ -3,7 +3,7 @@ package xoa
 import (
 	"errors"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/xoa/resource_xenorchestra_cloud_config.go
+++ b/xoa/resource_xenorchestra_cloud_config.go
@@ -1,7 +1,7 @@
 package xoa
 
 import (
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/xoa/resource_xenorchestra_cloud_config_test.go
+++ b/xoa/resource_xenorchestra_cloud_config_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )

--- a/xoa/resource_xenorchestra_network.go
+++ b/xoa/resource_xenorchestra_network.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/xoa/resource_xenorchestra_resource_set.go
+++ b/xoa/resource_xenorchestra_resource_set.go
@@ -3,7 +3,7 @@ package xoa
 import (
 	"log"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/xoa/resource_xenorchestra_resource_set_test.go
+++ b/xoa/resource_xenorchestra_resource_set_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
-	"github.com/ddelnano/terraform-provider-xenorchestra/xoa/internal"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/xoa/internal"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )

--- a/xoa/resource_xenorchestra_vdi.go
+++ b/xoa/resource_xenorchestra_vdi.go
@@ -1,7 +1,7 @@
 package xoa
 
 import (
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/xoa/resource_xenorchestra_vdi_test.go
+++ b/xoa/resource_xenorchestra_vdi_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
-	"github.com/ddelnano/terraform-provider-xenorchestra/xoa/internal"
-	"github.com/ddelnano/terraform-provider-xenorchestra/xoa/internal/state"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/xoa/internal"
+	"github.com/vatesfr/terraform-provider-xenorchestra/xoa/internal/state"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -207,7 +207,7 @@ $ xo-cli xo.getAllObjects filter='json:{"id": "cf7b5d7d-3cd5-6b7c-5025-5c935c8cd
   "max": 4,
   "number": 2
 }
-		    
+
 # Updating the VM to use 3 CPUs would happen without stopping/starting the VM
 # Updating the VM to use 5 CPUs would stop/start the VM
 ` + "```" + `

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ddelnano/terraform-provider-xenorchestra/client"
-	"github.com/ddelnano/terraform-provider-xenorchestra/xoa/internal"
+	"github.com/vatesfr/terraform-provider-xenorchestra/client"
+	"github.com/vatesfr/terraform-provider-xenorchestra/xoa/internal"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"


### PR DESCRIPTION
This is the second part of #302. Since jenkins cannot run on community contributed PRs, I'm pulling the commits out to here. The only difference is the that `client/go.{mod,sum}` changes and anything related to that were removed as mentioned in https://github.com/vatesfr/terraform-provider-xenorchestra/pull/302#issuecomment-1978004538.