### PR TITLE
Prevent local acc test runs from clashing with Jenkins builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 TIMEOUT ?= 40m
 GOMAXPROCS ?= 5
 TF_VERSION ?= v0.14.11
+ROOT_PKG_PATH := github.com/ddelnano/terraform-provider-xenorchestra
 ifdef TEST
     TEST := github.com/ddelnano/terraform-provider-xenorchestra/xoa -run '$(TEST)'
 else
@@ -35,10 +36,10 @@ sweep:
 test: testclient testacc
 
 testclient:
-	cd client; go test $(TEST) -v -count 1
+	cd client; go test $(TEST) -v -count 1 -ldflags "-X $(ROOT_PKG_PATH)/client.integrationTestPrefix=adhoc-xo-go-client"
 
 testacc: xoa/testdata/alpine-virt-3.17.0-x86_64.iso
-	TF_ACC=1 $(TF_LOG) go test $(TEST) -parallel $(GOMAXPROCS) -v -count 1 -timeout $(TIMEOUT) -sweep=true
+	TF_ACC=1 $(TF_LOG) go test $(TEST) -parallel $(GOMAXPROCS) -v -count 1 -timeout $(TIMEOUT) -sweep=true -ldflags "-X $(ROOT_PKG_PATH)/xoa.accTestPrefix=adhoc-terraform-acc"
 
 # This file was previously stored in the git repo with git lfs. GitHub
 # has a very low quota for number of allowed clones and so this needed

--- a/client/setup_test.go
+++ b/client/setup_test.go
@@ -36,7 +36,7 @@ func CreateNetwork(network *Network) {
 	*network = *net
 }
 
-var integrationTestPrefix string = "xenorchestra-client-"
+var integrationTestPrefix string = "xo-go-client-"
 var accTestPool Pool
 var accTestHost Host
 var accDefaultSr StorageRepository


### PR DESCRIPTION
Summary: Prevent local acc test runs from clashing with Jenkins builds

This addresses #290.

Test plan:
- [x] `make testacc` did not impact an in progress jenkins run