### PR TITLE
Set 'repository' in Installation when method is 'network'

### DIFF
--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -525,6 +525,7 @@ func resourceVmCreate(d *schema.ResourceData, m interface{}) error {
 	if installMethod := d.Get("installation_method").(string); installMethod != "" {
 		installation = client.Installation{
 			Method: "network",
+			Repository: "pxe",
 		}
 	}
 


### PR DESCRIPTION
This PR makes the provider behave the same as the XO UI.
The UI will set repository to `pxe` when `network` method is selected.

The `repository` field is mandatory, and must have length > 0 (all strings do) as seen [in the XO code](https://github.com/vatesfr/xen-orchestra/blob/6056a618c3e503fcc0de4fe19007574e40bfddd5/packages/xo-server/src/xo-mixins/rest-api.mjs#L309)

fixes #311 