### PR TITLE
Fix/issue 342 include accidental deletion

### DIFF
--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -164,7 +164,7 @@ $ xo-cli xo.getAllObjects filter='json:{"id": "cf7b5d7d-3cd5-6b7c-5025-5c935c8cd
 
 - `affinity_host` (String) The preferred host you would like the VM to run on. If changed on an existing VM it will require a reboot for the VM to be rescheduled.
 - `auto_poweron` (Boolean) If the VM will automatically turn on. Defaults to `false`.
-- `blocked_operations` (Set of String) List of operations on a VM that are not permitted. Examples include: clean_reboot, clean_shutdown, hard_reboot, hard_shutdown, pause, shutdown, suspend, destroy. This can be used to prevent a VM from being destroyed. The entire list can be found here
+- `blocked_operations` (Set of String) List of operations on a VM that are not permitted. Examples include: clean_reboot, clean_shutdown, hard_reboot, hard_shutdown, pause, shutdown, suspend, destroy. See: https://xapi-project.github.io/xen-api/classes/vm.html#enum_vm_operations
 - `cdrom` (Block List, Max: 1) The ISO that should be attached to VM. This allows you to create a VM from a diskless template (any templates available from `xe template-list`) and install the OS from the following ISO. (see [below for nested schema](#nestedblock--cdrom))
 - `clone_type` (String) The type of clone to perform for the VM. Possible values include `fast` or `full` and defaults to `fast`. In order to perform a `full` clone, the VM template must not be a disk template.
 - `cloud_config` (String) The content of the cloud-init config to use. See the cloud init docs for more [information](https://cloudinit.readthedocs.io/en/latest/topics/examples.html).

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -607,6 +607,7 @@ func resourceVmCreate(d *schema.ResourceData, m interface{}) error {
 		params := map[string]any{
 			"id":                vm.Id,
 			"blockedOperations": newBlockedOps,
+			// if xenStoreData isn't provided, the update will fail.
 			"xenStoreData": map[string]string{
 				"vm-data":                "blocked-operations-update",
 				"vm-data/mmio-hole-size": "268435456",
@@ -619,7 +620,6 @@ func resourceVmCreate(d *schema.ResourceData, m interface{}) error {
 			return fmt.Errorf("failed to update vm blocked operations: %w", err)
 		}
 
-		// Refresh VM data
 		updatedVm, err := c.GetVm(client.Vm{Id: vm.Id})
 		if err != nil {
 			return fmt.Errorf("failed to refresh vm data: %w", err)

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -602,11 +602,6 @@ func resourceVmCreate(d *schema.ResourceData, m interface{}) error {
 		params := map[string]any{
 			"id":                vm.Id,
 			"blockedOperations": newBlockedOps,
-			// if xenStoreData isn't provided, the update will fail.
-			"xenStoreData": map[string]string{
-				"vm-data":                "blocked-operations-update",
-				"vm-data/mmio-hole-size": "268435456",
-			},
 		}
 
 		var success bool
@@ -615,11 +610,7 @@ func resourceVmCreate(d *schema.ResourceData, m interface{}) error {
 			return fmt.Errorf("failed to update vm blocked operations: %w", err)
 		}
 
-		updatedVm, err := c.GetVm(client.Vm{Id: vm.Id})
-		if err != nil {
-			return fmt.Errorf("failed to refresh vm data: %w", err)
-		}
-		vm = updatedVm
+		vm.BlockedOperations = newBlockedOps
 	}
 
 	vifs, err := c.GetVIFs(vm)


### PR DESCRIPTION
Related to issue: https://github.com/vatesfr/terraform-provider-xenorchestra/issues/342

When we successfully created the vm, an update is produced to have the expected blocked operations without the error shown in the issue. 

Step to verify is to create a main.tf with your configuration, then when terraform applied it without error, you can use xo-cli rest get vms/your-uuid and you can check the field blockedOperations. 

The shared screenshots aim to show that after applying with the blocked operations set to true we cannot delete the vm.

![tf-apply-working](https://github.com/user-attachments/assets/d67bd371-e622-4f38-a1e8-1f33ecdc748d)


<img width="557" alt="Screenshot 2025-02-24 at 16 31 14" src="https://github.com/user-attachments/assets/8a18229f-a406-474f-8e0d-6495195c5586" />


![try-terraform-destroy-expected-error](https://github.com/user-attachments/assets/9d644e92-cbb7-4ee6-9fe1-7d5c20374194)

<img width="1073" alt="try-delete-expected-error" src="https://github.com/user-attachments/assets/8d5c725d-0e3f-4d5e-b1c1-1e0d6354c458" />
