### PR TITLE
fix issue when ignoring destroy_cloud_config_vdi_after_boot

### DIFF
--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -74,9 +74,10 @@ func resourceVm() *schema.Resource {
 func vmDestroyCloudConfigCustomizeDiff(ctx context.Context, diff *schema.ResourceDiff, v interface{}) error {
 	destroyCloudConfig := diff.Get("destroy_cloud_config_vdi_after_boot").(bool)
 	powerState := diff.Get("power_state").(string)
+	powerStateChanged := diff.HasChange("power_state")
 
-	if destroyCloudConfig && powerState != client.RunningPowerState {
-		return errors.New(fmt.Sprintf("power_state must be `%s` when destroy_cloud_config_vdi_after_boot set to `true`", client.RunningPowerState))
+	if powerStateChanged && destroyCloudConfig && powerState != client.RunningPowerState {
+		return fmt.Errorf("power_state must be `%s` when destroy_cloud_config_vdi_after_boot set to `true`", client.RunningPowerState)
 	}
 	return nil
 }


### PR DESCRIPTION
Will fix #338 

When destroy_cloud_config_vdi_after_boot is set to true, it requires the set the power_state to "Running" even if the power_state changes are ignored in resource lifecycle (for example when the cm is stopped).

With this PR, when destroy_cloud_config_vdi_after_boot=true it will check if power_state is "Running" only if it has changed