### PR TITLE
fix: bug with network update that failed with the error "vif in use"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,13 @@
 module github.com/vatesfr/terraform-provider-xenorchestra
 
-go 1.21
+go 1.24
+
+toolchain go1.24.3
 
 require (
 	github.com/hashicorp/terraform-plugin-docs v0.18.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0
-	github.com/vatesfr/xenorchestra-go-sdk v1.0.0
+	github.com/vatesfr/xenorchestra-go-sdk v1.1.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -182,10 +182,10 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/vatesfr/xenorchestra-go-sdk v1.0.0 h1:zvzHsYzyLC3W2NPK/IVujFrg3XQ6bcDjPBkQAKmFJYE=
-github.com/vatesfr/xenorchestra-go-sdk v1.0.0/go.mod h1:UiMo2zLd34/jYFU7omq3+9daoRLJQOrzqOre7bV0UG0=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/vatesfr/xenorchestra-go-sdk v1.1.0 h1:O7VbvBQ1rogzI5Xv8Me88CrRUGwrK/vMXT2CUmCToK0=
+github.com/vatesfr/xenorchestra-go-sdk v1.1.0/go.mod h1:3679gtr7PLytF3C9/QeF/llA0L5ZRvXfaP1oWtk7Hf4=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/xoa/resource_xenorchestra_bonded_network.go
+++ b/xoa/resource_xenorchestra_bonded_network.go
@@ -125,9 +125,8 @@ func resourceBondedNetworkUpdate(d *schema.ResourceData, m interface{}) error {
 	c := m.(client.XOClient)
 
 	netUpdateReq := client.UpdateNetworkRequest{
-		Id:              d.Id(),
-		Automatic:       d.Get("automatic").(bool),
-		DefaultIsLocked: d.Get("default_is_locked").(bool),
+		Id:        d.Id(),
+		Automatic: d.Get("automatic").(bool),
 	}
 	if d.HasChange("name_label") {
 		nameLabel := d.Get("name_label").(string)
@@ -136,6 +135,10 @@ func resourceBondedNetworkUpdate(d *schema.ResourceData, m interface{}) error {
 	if d.HasChange("name_description") {
 		nameDescription := d.Get("name_description").(string)
 		netUpdateReq.NameDescription = &nameDescription
+	}
+	if d.HasChange("default_is_locked") {
+		defaultIsLocked := d.Get("default_is_locked").(bool)
+		netUpdateReq.DefaultIsLocked = &defaultIsLocked
 	}
 	_, err := c.UpdateNetwork(netUpdateReq)
 	if err != nil {

--- a/xoa/resource_xenorchestra_network.go
+++ b/xoa/resource_xenorchestra_network.go
@@ -190,10 +190,9 @@ func resourceNetworkUpdate(d *schema.ResourceData, m interface{}) error {
 	c := m.(client.XOClient)
 
 	netUpdateReq := client.UpdateNetworkRequest{
-		Id:              d.Id(),
-		Automatic:       d.Get("automatic").(bool),
-		DefaultIsLocked: d.Get("default_is_locked").(bool),
-		Nbd:             d.Get("nbd").(bool),
+		Id:        d.Id(),
+		Automatic: d.Get("automatic").(bool),
+		Nbd:       d.Get("nbd").(bool),
 	}
 	if d.HasChange("name_label") {
 		nameLabel := d.Get("name_label").(string)
@@ -202,6 +201,10 @@ func resourceNetworkUpdate(d *schema.ResourceData, m interface{}) error {
 	if d.HasChange("name_description") {
 		nameDescription := d.Get("name_description").(string)
 		netUpdateReq.NameDescription = &nameDescription
+	}
+	if d.HasChange("default_is_locked") {
+		defaultIsLocked := d.Get("default_is_locked").(bool)
+		netUpdateReq.DefaultIsLocked = &defaultIsLocked
 	}
 	_, err := c.UpdateNetwork(netUpdateReq)
 	if err != nil {


### PR DESCRIPTION
This is related to issue https://github.com/vatesfr/terraform-provider-xenorchestra/issues/347 on terraform-provider-xenorchestra and come with https://github.com/vatesfr/xenorchestra-go-sdk/pull/18

The problem was that the param default_is_locked was always sent with the update, that make the request failed when the VIF is used.