### PR TITLE
feat: Add host_id filtering to xenorchestra_sr data source

### DIFF
--- a/docs/data-sources/sr.md
+++ b/docs/data-sources/sr.md
@@ -5,7 +5,7 @@ subcategory: ""
 description: |-
   Provides information about a Storage repository to ease the lookup of VM storage information.
   Note: If there are multiple storage repositories that match terraform will fail.
-  Ensure that your name_label, pool_id and tags identify a unique storage repository.
+  Ensure that your name_label, pool_id, host_id and tags identify a unique storage repository.
 ---
 
 # xenorchestra_sr (Data Source)
@@ -13,7 +13,7 @@ description: |-
 Provides information about a Storage repository to ease the lookup of VM storage information.
 
 **Note:** If there are multiple storage repositories that match terraform will fail.
-Ensure that your name_label, pool_id and tags identify a unique storage repository.
+Ensure that your name_label, pool_id, host_id and tags identify a unique storage repository.
 
 ## Example Usage
 
@@ -42,6 +42,7 @@ resource "xenorchestra_vm" "demo-vm" {
 
 ### Optional
 
+- `host_id` (String) The Id of the host the storage repository exists on. For host-local storage repositories the SR's `container` is the host itself, so this filters the repositories down to a single host when several hosts in the pool share the same SR name.
 - `pool_id` (String) The Id of the pool the storage repository exists on.
 - `tags` (Set of String) The tags (labels) applied to the given entity. Not used for filtering if empty.
 

--- a/xoa/data_source_xenorchestra_sr.go
+++ b/xoa/data_source_xenorchestra_sr.go
@@ -14,7 +14,7 @@ func dataSourceXoaStorageRepository() *schema.Resource {
 		Description: `Provides information about a Storage repository to ease the lookup of VM storage information.
 
 **Note:** If there are multiple storage repositories that match terraform will fail.
-Ensure that your name_label, pool_id and tags identify a unique storage repository.`,
+Ensure that your name_label, pool_id, host_id and tags identify a unique storage repository.`,
 		Schema: map[string]*schema.Schema{
 			"name_label": &schema.Schema{
 				Description: "The name of the storage repository to look up",
@@ -28,6 +28,11 @@ Ensure that your name_label, pool_id and tags identify a unique storage reposito
 			},
 			"pool_id": &schema.Schema{
 				Description: "The Id of the pool the storage repository exists on.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
+			"host_id": &schema.Schema{
+				Description: "The Id of the host the storage repository exists on. For host-local storage repositories the SR's `container` is the host itself, so this filters the repositories down to a single host when several hosts in the pool share the same SR name.",
 				Type:        schema.TypeString,
 				Optional:    true,
 			},
@@ -66,6 +71,7 @@ func dataSourceStorageRepositoryRead(d *schema.ResourceData, m interface{}) erro
 
 	nameLabel := d.Get("name_label").(string)
 	poolId := d.Get("pool_id").(string)
+	hostId := d.Get("host_id").(string)
 	tags := d.Get("tags").(*schema.Set).List()
 
 	sr := client.StorageRepository{
@@ -78,6 +84,18 @@ func dataSourceStorageRepositoryRead(d *schema.ResourceData, m interface{}) erro
 
 	if err != nil {
 		return err
+	}
+
+	// The SDK cannot filter by host, but for host-local SRs the SR's
+	// `container` is the host that owns it, so filter by container here.
+	if hostId != "" {
+		filtered := make([]client.StorageRepository, 0, len(srs))
+		for _, s := range srs {
+			if s.Container == hostId {
+				filtered = append(filtered, s)
+			}
+		}
+		srs = filtered
 	}
 
 	l := len(srs)

--- a/xoa/data_source_xenorchestra_sr_test.go
+++ b/xoa/data_source_xenorchestra_sr_test.go
@@ -93,6 +93,46 @@ func TestAccXenorchestraDataSource_storageRepositoryWithNonExistantPoolId(t *tes
 	)
 }
 
+func TestAccXenorchestraDataSource_storageRepositoryWithHostId(t *testing.T) {
+	resourceName := "data.xenorchestra_sr.sr"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccXenorchestraDataSourceStorageRepositoryHostConfig(accTestPool.Id, accTestHost.Id),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckXenorchestraDataSourceStorageRepository(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "sr_type"),
+					resource.TestCheckResourceAttrSet(resourceName, "pool_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "uuid"),
+					resource.TestCheckResourceAttrSet(resourceName, "container"),
+					resource.TestCheckResourceAttr(resourceName, "name_label", accDefaultSr.NameLabel),
+					resource.TestCheckResourceAttr(resourceName, "host_id", accTestHost.Id)),
+			},
+		},
+	},
+	)
+}
+
+func TestAccXenorchestraDataSource_storageRepositoryWithNonExistantHostId(t *testing.T) {
+	// Proves the host filter narrows the results: SRs with the default name
+	// exist in the test pool, but none live on a host with this id, so the
+	// lookup must come back empty instead of returning a match.
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccXenorchestraDataSourceStorageRepositoryHostConfig(accTestPool.Id, "00000000-0000-0000-0000-000000000000"),
+				ExpectError: regexp.MustCompile("found `0` srs that match"),
+			},
+		},
+	},
+	)
+}
+
 func testAccCheckXenorchestraDataSourceStorageRepository(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -129,4 +169,17 @@ data "xenorchestra_sr" "sr" {
 }
 `, accDefaultSr.NameLabel, poolId, accTestPrefix)
 
+}
+
+func testAccXenorchestraDataSourceStorageRepositoryHostConfig(poolId string, hostId string) string {
+	return fmt.Sprintf(`
+data "xenorchestra_sr" "sr" {
+    name_label = "%s"
+    pool_id = "%s"
+    host_id = "%s"
+    tags = [
+	"%s"
+    ]
+}
+`, accDefaultSr.NameLabel, poolId, hostId, accTestPrefix)
 }

--- a/xoa/data_source_xenorchestra_sr_test.go
+++ b/xoa/data_source_xenorchestra_sr_test.go
@@ -3,6 +3,7 @@ package xoa
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -18,7 +19,9 @@ func TestAccXenorchestraDataSource_storageRepository(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccXenorchestraDataSourceStorageRepositoryConfig(accDefaultSr.NameLabel),
+				Config: testAccXenorchestraDataSourceStorageRepositoryConfig(storageRepositoryConfig{
+					nameLabel: accDefaultSr.NameLabel,
+				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckXenorchestraDataSourceStorageRepository(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
@@ -43,7 +46,9 @@ func TestAccXenorchestraDataSource_storageRepositoryNotFound(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccXenorchestraDataSourceStorageRepositoryConfig("not found"),
+				Config: testAccXenorchestraDataSourceStorageRepositoryConfig(storageRepositoryConfig{
+					nameLabel: "not found",
+				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckXenorchestraDataSourceStorageRepository(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
@@ -65,7 +70,10 @@ func TestAccXenorchestraDataSource_storageRepositoryWithPoolId(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccXenorchestraDataSourceStorageRepositoryPoolConfig(accDefaultSr.PoolId),
+				Config: testAccXenorchestraDataSourceStorageRepositoryConfig(storageRepositoryConfig{
+					nameLabel: accDefaultSr.NameLabel,
+					poolID:    accDefaultSr.PoolId,
+				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckXenorchestraDataSourceStorageRepository(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
@@ -85,7 +93,10 @@ func TestAccXenorchestraDataSource_storageRepositoryWithNonExistantPoolId(t *tes
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccXenorchestraDataSourceStorageRepositoryPoolConfig(nonExistantPoolId),
+				Config: testAccXenorchestraDataSourceStorageRepositoryConfig(storageRepositoryConfig{
+					nameLabel: accDefaultSr.NameLabel,
+					poolID:    nonExistantPoolId,
+				}),
 				ExpectError: regexp.MustCompile(`Could not find client.StorageRepository with query`),
 			},
 		},
@@ -100,7 +111,10 @@ func TestAccXenorchestraDataSource_storageRepositoryWithHostId(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccXenorchestraDataSourceStorageRepositoryHostConfig(accTestPool.Id, accTestHost.Id),
+				Config: testAccXenorchestraDataSourceStorageRepositoryConfig(storageRepositoryConfig{
+					poolID: accTestPool.Id,
+					hostID: accTestHost.Id,
+				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckXenorchestraDataSourceStorageRepository(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
@@ -125,7 +139,10 @@ func TestAccXenorchestraDataSource_storageRepositoryWithNonExistantHostId(t *tes
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccXenorchestraDataSourceStorageRepositoryHostConfig(accTestPool.Id, "00000000-0000-0000-0000-000000000000"),
+				Config: testAccXenorchestraDataSourceStorageRepositoryConfig(storageRepositoryConfig{
+					poolID: accTestPool.Id,
+					hostID: "00000000-0000-0000-0000-000000000000",
+				}),
 				ExpectError: regexp.MustCompile("found `0` srs that match"),
 			},
 		},
@@ -147,39 +164,24 @@ func testAccCheckXenorchestraDataSourceStorageRepository(n string) resource.Test
 	}
 }
 
-func testAccXenorchestraDataSourceStorageRepositoryConfig(srNameLabel string) string {
-	return fmt.Sprintf(`
-data "xenorchestra_sr" "sr" {
-    name_label = "%s"
-    tags = [
-	"%s"
-    ]
-}
-`, srNameLabel, accTestPrefix)
+type storageRepositoryConfig struct {
+	nameLabel string
+	poolID    string
+	hostID    string
 }
 
-func testAccXenorchestraDataSourceStorageRepositoryPoolConfig(poolId string) string {
+func testAccXenorchestraDataSourceStorageRepositoryConfig(config storageRepositoryConfig) string {
+	var optionalAttributes strings.Builder
+	if config.poolID != "" {
+		fmt.Fprintf(&optionalAttributes, "    pool_id = %q\n", config.poolID)
+	}
+	if config.hostID != "" {
+		fmt.Fprintf(&optionalAttributes, "    host_id = %q\n", config.hostID)
+	}
 	return fmt.Sprintf(`
 data "xenorchestra_sr" "sr" {
-    name_label = "%s"
-    pool_id = "%s"
-    tags = [
-	"%s"
-    ]
+    name_label = %q
+%s    tags = [%q]
 }
-`, accDefaultSr.NameLabel, poolId, accTestPrefix)
-
-}
-
-func testAccXenorchestraDataSourceStorageRepositoryHostConfig(poolId string, hostId string) string {
-	return fmt.Sprintf(`
-data "xenorchestra_sr" "sr" {
-    name_label = "%s"
-    pool_id = "%s"
-    host_id = "%s"
-    tags = [
-	"%s"
-    ]
-}
-`, accDefaultSr.NameLabel, poolId, hostId, accTestPrefix)
+`, config.nameLabel, optionalAttributes.String(), accTestPrefix)
 }


### PR DESCRIPTION
## Summary

Fixes #416

The `xenorchestra_sr` data source could only filter by `name_label`, `pool_id` and `tags`. When several hosts in a pool each own a host-local SR with the same name (e.g. `Local storage` on every host), the lookup matched multiple SRs and failed with:

> found `3` srs that match [...]. Storage repositories must be uniquely named to use this data source

## Approach

Adds an optional `host_id` argument to the data source. The SDK cannot filter SRs by host, but for host-local SRs the SR's `container` **is** the hosting host, so the results are post-filtered by `Container == host_id` in the provider. This mirrors the existing `host_id` argument on the `xenorchestra_pif` data source.

### Usage

```hcl
data "xenorchestra_sr" "local_storages" {
  for_each   = var.nodes
  name_label = each.value.sr
  pool_id    = data.xenorchestra_host.hosts[each.key].pool_id
  host_id    = data.xenorchestra_host.hosts[each.key].id
}
```

## Changes

- `xoa/data_source_xenorchestra_sr.go`: new optional `host_id` input + container-based post-filter, updated description
- `xoa/data_source_xenorchestra_sr_test.go`: acceptance tests for the new filter (positive + non-existent host)
- `docs/data-sources/sr.md`: regenerated with tfplugindocs

## Notes

- `host_id` resolves ambiguity for **host-local** SRs only. A shared pool SR has the pool as its container, so `host_id` does not disambiguate those (documented in the field description).
- A more general fix would be a host field in the SDK's `StorageRepository` struct, but that requires an upstream SDK release; this provider-side change is self-contained.