### PR TITLE
feat: add share option to xenorchestra_vm resource

### DIFF
--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -172,6 +172,7 @@ $ xo-cli xo.getAllObjects filter='json:{"id": "cf7b5d7d-3cd5-6b7c-5025-5c935c8cd
 - `power_state` (String) The power state of the VM. This can be Running, Halted, Paused or Suspended.
 - `resource_set` (String)
 - `secure_boot` (Boolean) Enable UEFI secure boot for the VM.
+- `share` (Boolean) Allow the subjects of the resource set to use the VM. Only applies when resource_set is set. Can be changed on an existing VM, but setting it to `false` requires the VM to leave its resource set at the same time, since a VM shared in a resource set is always shared in Xen Orchestra (there is no unshare operation).
 - `start_delay` (Number) Number of seconds the VM should be delayed from starting.
 - `tags` (Set of String) The tags (labels) applied to the given entity. Not used for filtering if empty.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.25.0
 	github.com/hashicorp/terraform-plugin-log v0.11.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
-	github.com/vatesfr/xenorchestra-go-sdk v1.18.0
+	github.com/vatesfr/xenorchestra-go-sdk v1.19.0
 )
 
 require (
@@ -61,7 +61,7 @@ require (
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
-	github.com/sourcegraph/jsonrpc2 v0.2.1 // indirect
+	github.com/sourcegraph/jsonrpc2 v0.2.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,6 @@ github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DV
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=
 github.com/pjbgf/sha1cd v0.3.2/go.mod h1:zQWigSxVmsHEZow5qaLtPYxpcKMMQpa09ixqBxuCS6A=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
-github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
@@ -183,8 +181,8 @@ github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5g
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
-github.com/sourcegraph/jsonrpc2 v0.2.1 h1:2GtljixMQYUYCmIg7W9aF2dFmniq/mOr2T9tFRh6zSQ=
-github.com/sourcegraph/jsonrpc2 v0.2.1/go.mod h1:ZafdZgk/axhT1cvZAPOhw+95nz2I/Ra5qMlU4gTRwIo=
+github.com/sourcegraph/jsonrpc2 v0.2.2 h1:fCyU80iidEwcF9kWaj4ylOO1h8pT8P8sFGv8EKemLaw=
+github.com/sourcegraph/jsonrpc2 v0.2.2/go.mod h1:ZafdZgk/axhT1cvZAPOhw+95nz2I/Ra5qMlU4gTRwIo=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=
 github.com/spf13/cast v1.5.0/go.mod h1:SpXXQ5YoyJw6s3/6cMTQuxvgRl3PCJiyaX9p6b155UU=
@@ -193,10 +191,10 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
-github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/vatesfr/xenorchestra-go-sdk v1.18.0 h1:9Q534BMu+h3+GIbjReUME5A+AITyVuEL4yfLT2MGC1M=
-github.com/vatesfr/xenorchestra-go-sdk v1.18.0/go.mod h1:OP2NfSLyqmFMfITRU8NoMMstitZ4nLTBXPVoLzRQ2Uo=
+github.com/stretchr/testify v1.12.0 h1:K6Mr6jO9JICuend/5xzTM03ydSV3vdNRYAdPSukj8uI=
+github.com/stretchr/testify v1.12.0/go.mod h1:bOYBZb5qJ00vPzWfIqBUZPaxK8jWiXc6d3ErP4Ca9Gw=
+github.com/vatesfr/xenorchestra-go-sdk v1.19.0 h1:QGFi9h6CioQFeNOLOmPfGiBt84uT1hDG/PtYkSZFsMA=
+github.com/vatesfr/xenorchestra-go-sdk v1.19.0/go.mod h1:lkAhxh9gLFZNLIubuMcjDKP49G2/H/h6wfWA3nWpO1o=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -60,6 +60,7 @@ func resourceVm() *schema.Resource {
 	delete(vmSchema, "cdrom")
 	delete(vmSchema, "installation_method")
 	delete(vmSchema, "destroy_cloud_config_vdi_after_boot")
+	delete(vmSchema, "share")
 	vmSchema["id"] = &schema.Schema{
 		Type:     schema.TypeString,
 		Required: true,
@@ -96,6 +97,19 @@ func vmCustomizeDiff(ctx context.Context, diff *schema.ResourceDiff, v interface
 	memoryHasChanged := diff.HasChanges("memory_max", "memory_min")
 	if memoryHasChanged && memoryMin > memoryMax {
 		return fmt.Errorf("memory_min (%d) must be less than or equal to memory_max (%d)", memoryMin, memoryMax)
+	}
+
+	// Check share constraints
+	oShare, nShare := diff.GetChange("share")
+	share := nShare.(bool)
+	if share && diff.Get("resource_set").(string) == "" {
+		return fmt.Errorf("resource_set must be specified when share is set to `true`")
+	}
+	// A VM shared in a resource set is always shared in Xen Orchestra (there is no
+	// unshare operation), so share can only be switched off if the VM is
+	// leaving its resource set at the same time.
+	if oShare.(bool) && !share && diff.Get("resource_set").(string) != "" {
+		return fmt.Errorf("share cannot be set to `false` while the VM stays in a resource set: unsharing requires removing resource_set, or recreating the VM")
 	}
 
 	// Check CPU topology constraints
@@ -276,6 +290,12 @@ $ xo-cli xo.getAllObjects filter='json:{"id": "cf7b5d7d-3cd5-6b7c-5025-5c935c8cd
 		"resource_set": &schema.Schema{
 			Type:     schema.TypeString,
 			Optional: true,
+		},
+		"share": &schema.Schema{
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Allow the subjects of the resource set to use the VM. Only applies when resource_set is set. Can be changed on an existing VM, but setting it to `false` requires the VM to leave its resource set at the same time, since a VM shared in a resource set is always shared in Xen Orchestra (there is no unshare operation).",
 		},
 		"ipv4_addresses": &schema.Schema{
 			Type:        schema.TypeList,
@@ -631,6 +651,12 @@ func resourceVmCreateContext(ctx context.Context, d *schema.ResourceData, m inte
 	affinityHost := d.Get("affinity_host").(string)
 	if affinityHost != "" {
 		createVmParams.AffinityHost = &affinityHost
+	}
+
+	// XO treats share=false and share absent identically, so only send it
+	// when true.
+	if share := d.Get("share").(bool); share {
+		createVmParams.Share = &share
 	}
 
 	// Set CPU topology if cores_per_socket is specified
@@ -1038,6 +1064,14 @@ func resourceVmUpdateContext(ctx context.Context, d *schema.ResourceData, m inte
 
 	if d.HasChange("affinity_host") {
 		vmReq.AffinityHost = &affinityHost
+	}
+
+	// share is only sent when it changes. A false -> true change is shared
+	// in place by XO; a true -> false change can only happen together with
+	// leaving the resource set, which XO handles on its own.
+	if d.HasChange("share") {
+		share := d.Get("share").(bool)
+		vmReq.Share = &share
 	}
 
 	if d.HasChange("xenstore") {

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -766,6 +766,81 @@ func TestAccXenorchestraVm_ensureVmsInResourceSetsCanBeUpdatedByNonAdminUsers(t 
 	})
 }
 
+func TestAccXenorchestraVm_shareInResourceSet(t *testing.T) {
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
+	resourceName := "xenorchestra_vm.bar"
+
+	// Capture the id of the first VM to prove that sharing happens in place
+	// (no recreation)
+	var vmId string
+	checkVmId := func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+		if vmId == "" {
+			vmId = rs.Primary.ID
+			return nil
+		}
+		if rs.Primary.ID != vmId {
+			return fmt.Errorf("VM should not have been recreated (id changed to %s)", rs.Primary.ID)
+		}
+		return nil
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckXenorchestraVmDestroy,
+		Steps: []resource.TestStep{
+			// Create the VM in a resource set, without sharing it
+			{
+				Config: testAccVmShareConfig(vmName, false),
+				Check: resource.ComposeTestCheckFunc(
+					checkVmId,
+					resource.TestCheckResourceAttr(resourceName, "share", "false"),
+				),
+			},
+			// Share the VM in place (no recreation)
+			{
+				Config: testAccVmShareConfig(vmName, true),
+				Check: resource.ComposeTestCheckFunc(
+					checkVmId,
+					resource.TestCheckResourceAttr(resourceName, "share", "true"),
+				),
+			},
+			// Unsharing while staying in the resource set is rejected at plan time
+			{
+				Config:      testAccVmShareConfig(vmName, false),
+				ExpectError: regexp.MustCompile("share cannot be set to `false` while the VM stays in a resource set"),
+			},
+			// Unshare the VM by removing it from the resource set (in place)
+			{
+				Config: testAccVmConfigWithoutResourceSet(vmName),
+				Check: resource.ComposeTestCheckFunc(
+					checkVmId,
+					resource.TestCheckResourceAttr(resourceName, "resource_set", ""),
+					resource.TestCheckResourceAttr(resourceName, "share", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccXenorchestraVm_shareRequiresResourceSet(t *testing.T) {
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccVmShareWithoutResourceSetConfig(vmName),
+				ExpectError: regexp.MustCompile("resource_set must be specified when share is set to `true`"),
+			},
+		},
+	})
+}
+
 func TestAccXenorchestraVm_cdromAndInstallationMethodsCannotBeSpecifiedTogether(t *testing.T) {
 	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
 	resource.ParallelTest(t, resource.TestCase{
@@ -3179,6 +3254,59 @@ resource "xenorchestra_resource_set" "rs" {
     }
 }
 `, accDefaultNetwork.NameLabel, accTestPool.Id, accTestPrefix, vmName, accUser.Id, accDefaultSr.Id)
+}
+
+func testAccVmShareConfig(vmName string, share bool) string {
+	shareAttr := ""
+	if share {
+		shareAttr = "share = true"
+	}
+	return testAccCloudConfigConfig(fmt.Sprintf("vm-template-%s", vmName), "template") + testAccVmResourceSet(vmName) + fmt.Sprintf(`
+
+resource "xenorchestra_vm" "bar" {
+    memory_max = 4295000000
+    cpus  = 1
+    cloud_config = xenorchestra_cloud_config.bar.template
+    name_label = "%s"
+    name_description = "description"
+    template = data.xenorchestra_template.template.id
+    resource_set = xenorchestra_resource_set.rs.id
+    %s
+    network {
+	network_id = data.xenorchestra_network.network.id
+    }
+
+    disk {
+      sr_id = "%s"
+      name_label = "disk 1"
+      size = 10001317888
+    }
+}
+`, vmName, shareAttr, accDefaultSr.Id)
+}
+
+func testAccVmShareWithoutResourceSetConfig(vmName string) string {
+	return testAccCloudConfigConfig(fmt.Sprintf("vm-template-%s", vmName), "template") + testAccVmResourceSet(vmName) + fmt.Sprintf(`
+
+resource "xenorchestra_vm" "bar" {
+    memory_max = 4295000000
+    cpus  = 1
+    cloud_config = xenorchestra_cloud_config.bar.template
+    name_label = "%s"
+    name_description = "description"
+    template = data.xenorchestra_template.template.id
+    share = true
+    network {
+	network_id = data.xenorchestra_network.network.id
+    }
+
+    disk {
+      sr_id = "%s"
+      name_label = "disk 1"
+      size = 10001317888
+    }
+}
+`, vmName, accDefaultSr.Id)
 }
 
 func testAccVmConfigWithoutResourceSet(vmName string) string {


### PR DESCRIPTION
Adds a `share` option to the `xenorchestra_vm` resource.

A VM that belongs to a resource set can be shared so that the other members of that resource set can use it (the XOA 'Share' button). The provider already managed `resource_set` but had no way to set `share`, since the SDK did not expose it.

- Add optional bool `share` attribute to the VM resource, with  validation in the custom diff: `share = true` requires a
  `resource_set`, and `share` can only be switched off together with  removing the resource set (XO has no unshare operation: a VM in a  resource set is always shared)
- Send `share` on create when true, and on update only when it changes
- Document the new attribute in `docs/resources/vm.md`
- Bump the SDK to the `feat-vm-share` branch pseudo-version  (`v1.18.1-0.20260826081953-4fa711e923c7`) which adds the `Share`  field to its VM API --> **TODO: bump to latest SDK version after SDK PR is merged**

Depends on vatesfr/xenorchestra-go-sdk#111 (once it merges and a
release is cut, bump to the released version).

Closes #340 